### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    # @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,5 +12,4 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-
 end

--- a/app/models/item_status.rb
+++ b/app/models/item_status.rb
@@ -8,5 +8,4 @@ class ItemStatus < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
-
 end

--- a/app/models/postage_payer.rb
+++ b/app/models/postage_payer.rb
@@ -4,5 +4,4 @@ class PostagePayer < ActiveHash::Base
     { id: 2, name: '着払い(購入者負担)' },
     { id: 3, name: '送料込み(出品者負担)' }
   ]
-
 end

--- a/app/models/preparation_day.rb
+++ b/app/models/preparation_day.rb
@@ -5,5 +5,4 @@ class PreparationDay < ActiveHash::Base
     { id: 3, name: '2~3日で発送' },
     { id: 4, name: '4~7日で発送' }
   ]
-
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,24 +1,24 @@
-<%# <li class='list'>
+ <li class='list'>
   <%= link_to "#" do %>
-  <%# <div class='item-img-content'>
+   <div class='item-img-content'>
     <%= image_tag item.image, class: "item-img" %> 
-    <%# 商品が売れていればsold outを表示しましょう %>
-      <%# <div class='sold-out'>
+    <%#  商品が売れていればsold outを表示しましょう %> 
+      <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div> %>
+      </div> 
     <%# //商品が売れていればsold outを表示しましょう %>
-  <%# </div>
+ </div>
   <div class='item-info'>
     <h3 class='item-name'>
       <%= item.name %>
-    <%# </h3>
+    </h3>
     <div class='item-price'>
-      <span><%= item.price円<br><%= item.postage_payer.name</span> %>
-    <%# <div class='star-btn'> %>
-      <%# <%= image_tag "star.png", class:"star-icon" %>
-      <%# <span class='star-count'>0</span> %>
-    <%# </div> %> 
-  <%# </div> %>
-  <%# </div> %>
-<%# <% end %> 
-<%# </li> %>
+      <span><%= item.price%>円<br><%= item.postage_payer.name%></span> 
+      <div class='star-btn'> 
+       <%= image_tag "star.png", class:"star-icon" %>
+      <span class='star-count'>0</span> 
+    </div> 
+  </div>
+ </div>
+ <% end %> 
+</li> 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,49 +131,22 @@
 
      <% else %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-       <% end %> 
-      </li>
-      
-      <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %> 
+           <div class='item-info'> 
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon"%> 
+               <span class='star-count'>0</span> 
+              </div>
             </div>
           </div>
-        </div>
         <% end %>
-      </li>
+      </li> 
 
     <% end %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,11 +125,11 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-    <%# <% if @items.present? %>
+     <% if @items.present? %>
       
-      <%# <%= render partial: 'item', collection: @items %>   
+      <%= render partial: 'item', collection: @items %>  
 
-    <%# <% else %>
+     <% else %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -154,7 +154,7 @@
             </div>
           </div>
         </div>
-        <%# <% end %> 
+       <% end %> 
       </li>
       
       <li class='list'>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it '価格の範囲が、¥300~¥9,999,999の間であること(10000000以上の場合)' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end


### PR DESCRIPTION
#What
商品一覧表示機能の実装

#Why
出品した商品がトップページで出品が新しい順で表示されるようにするため

#gif一覧
[出品商品がない状態を明らかにした動画](https://gyazo.com/e3ff7048b57198cd4ae312030addb7c7)
[一覧表示を明らかにした動画(ログアウト状態含む)](https://gyazo.com/607492e2d09280998032c440479b5775)